### PR TITLE
Added test for useTime

### DIFF
--- a/src/hooks/useGlobals.ts
+++ b/src/hooks/useGlobals.ts
@@ -105,6 +105,6 @@ export const createGlobals = () => {
 const globals = createGlobals();
 
 export const useGlobals = () => globals as Globals;
-export const useTestGlobals = () => useGlobals() as TestGlobals;
+export const useTestGlobals = () => globals as unknown as TestGlobals;
 
 export default useGlobals;

--- a/src/hooks/useTime.test.ts
+++ b/src/hooks/useTime.test.ts
@@ -1,0 +1,52 @@
+import { renderHook, act } from "@testing-library/react-hooks";
+import { useTime } from "./useTime";
+import { useTestGlobals } from "./useGlobals";
+
+describe(useTime, () => {
+    it("defaults time to start time when first called", () => {
+        const startTime = 2000;
+        const rendered = renderHook(() => useTime({ paused: false, startTime }));
+
+        expect(rendered.result.current[0]).toEqual(startTime);
+    });
+
+    it("increases time by a second when a second has passed while not paused", () => {
+        const startTime = 2000;
+        const rendered = renderHook(() => useTime({ paused: false, startTime }));
+        const { clock } = useTestGlobals();
+
+        act(() => {
+            clock.tick(1000);
+        });
+
+        expect(rendered.result.current[0]).toEqual(startTime + 1000);
+    });
+
+    it("does not increase time by a second when a second has passed while paused", () => {
+        const startTime = 2000;
+        const rendered = renderHook(() => useTime({ paused: true, startTime }));
+        const { clock } = useTestGlobals();
+
+        act(() => {
+            clock.tick(1000);
+        });
+
+        expect(rendered.result.current[0]).toEqual(startTime);
+    });
+
+    it("resets start time when reset is called", () => {
+        const startTime = 2000;
+        const rendered = renderHook(() => useTime({ paused: false, startTime }));
+        const { clock } = useTestGlobals();
+
+        act(() => {
+            clock.tick(1000);
+        });
+
+        act(() => {
+            rendered.result.current[1]();
+        });
+
+        expect(rendered.result.current[0]).toEqual(startTime);
+    });
+});

--- a/src/hooks/useTime.ts
+++ b/src/hooks/useTime.ts
@@ -6,10 +6,10 @@ export const frequency = 1000;
 
 export type UseTimeSettings = {
     paused?: boolean;
-    startTime?: number;
+    startTime: number;
 };
 
-export const useTime = ({ paused, startTime = 0 }: UseTimeSettings = {}) => {
+export const useTime = ({ paused, startTime }: UseTimeSettings) => {
     const { clearInterval, setInterval } = useGlobals();
     const [time, setTime] = useState(startTime);
 


### PR DESCRIPTION
Starts on the fun tests in #23. Proof-of-concept that `useGlobals`, you know, works. 😄 